### PR TITLE
epic removing redundant props from coinState

### DIFF
--- a/constants/Api.ts
+++ b/constants/Api.ts
@@ -38,7 +38,6 @@ export const SPECS_CURRENCIES = {
   usd: 'USD',
   eur: 'EUR',
   aud: 'AUD',
-  bhd: 'BHD',
 } as const;
 
 export const DEFAULT_CURRENCIES_SELECTED_FOR_UI = {
@@ -46,5 +45,4 @@ export const DEFAULT_CURRENCIES_SELECTED_FOR_UI = {
   usd: true,
   eur: false,
   aud: false,
-  bhd: false,
 } as const;

--- a/contexts/coinsContext.tsx
+++ b/contexts/coinsContext.tsx
@@ -37,9 +37,7 @@ const getDynamicAvailableState = <T extends Record<string, boolean>>(
 
 const CoinsContext = createContext<CoinsContextType>({
   coinState: {
-    currency: DEFAULT.currency,
     currencyKey: DEFAULT.currencyKey,
-    ticker: DEFAULT.ticker,
     tickerKey: DEFAULT.tickerKey,
   },
   setCoinState: () => {},
@@ -118,9 +116,7 @@ export const CoinsProvider = ({ children }: any) => {
 
   const storedSettings = getStoredObject('settings');
   const [coinState, setCoinState] = useState<CoinState>({
-    currency: storedSettings?.currency || DEFAULT.currency,
     currencyKey: storedSettings?.currencyKey || DEFAULT.currencyKey,
-    ticker: storedSettings?.ticker || DEFAULT.ticker,
     tickerKey: storedSettings?.tickerKey || DEFAULT.tickerKey,
   });
 
@@ -147,23 +143,18 @@ export const CoinsProvider = ({ children }: any) => {
   );
 
   const handleCurrencyChange = (newCurrencyKey: CurrencyKey) => {
-    const _currency = SPECS_CURRENCIES[newCurrencyKey];
-
     setCoinState((prev) => ({
       ...prev,
       currencyKey: newCurrencyKey,
-      currency: _currency,
     }));
   };
 
   const handleTickerSelect = (newTickerKey: TickerKey) => {
-    const _ticker = SPECS_TICKERS[newTickerKey];
     const _selectedTickerOption = tickerOptions.find((option) => option.value === newTickerKey);
 
     setCoinState((prev) => ({
       ...prev,
       tickerKey: newTickerKey,
-      ticker: _ticker,
     }));
 
     if (_selectedTickerOption) setSelectedTickerOption(_selectedTickerOption);
@@ -234,6 +225,7 @@ export const CoinsProvider = ({ children }: any) => {
 
   const loadPersistedSettings = () => {
     const storedSettings = getStoredObject('settings');
+    console.log('🚀  |  file: coinsContext.tsx:228  |  loadPersistedSettings  |  storedSettings:', storedSettings);
     if (storedSettings) {
       setCoinState((prev) => ({
         ...prev,

--- a/hooks/useTickerData.ts
+++ b/hooks/useTickerData.ts
@@ -11,6 +11,7 @@ import {
   CurrencyValue,
 } from '../types/types';
 import { SPECS_CURRENCIES, SPECS_TICKERS } from '@/constants/Api';
+import { getTicker, getCurrency } from '@/utils/utils';
 
 export const useTickerData = () => {
   const { coinState, combinedTickerData } = useCoins();
@@ -31,17 +32,30 @@ export const useTickerData = () => {
     currencies: [],
   });
 
+  const ticker = getTicker(coinState.tickerKey);
+  const currency = getCurrency(coinState.currencyKey);
+
   useEffect(() => {
+    if (!combinedTickerData || !ticker || !currency) {
+      return;
+    }
+
+    const componentData = combinedTickerData[ticker];
+
+    if (!componentData) {
+      return;
+    }
+
     if (combinedTickerData) {
-      const componentData = combinedTickerData[coinState.ticker];
+      const componentData = combinedTickerData[ticker];
 
       if (componentData) {
         const { quotes: componentQuotes, last_updated: timeAgoData } = componentData;
 
         const percentChanges: Record<string, string | undefined> = {};
 
-        if (componentQuotes && componentQuotes[coinState.currency]) {
-          const currencyQuotes = componentQuotes[coinState.currency] as TickerQuote;
+        if (componentQuotes && componentQuotes[currency]) {
+          const currencyQuotes = componentQuotes[currency] as TickerQuote;
 
           const orderedKeys: (keyof TickerQuote)[] = [
             'percent_change_15m',
@@ -67,7 +81,7 @@ export const useTickerData = () => {
           isLast: index === array.length - 1,
         }));
 
-        const price = componentQuotes[coinState.currency]?.price || '0';
+        const price = componentQuotes[currency]?.price || '0';
 
         const tickers = Object.entries(SPECS_TICKERS).map(([key, value]) => ({
           key: key as TickerKey,
@@ -89,7 +103,7 @@ export const useTickerData = () => {
         });
       }
     }
-  }, [combinedTickerData, coinState.ticker, coinState.currency]);
+  }, [combinedTickerData, coinState]);
 
   return tickerData;
 };

--- a/types/types.ts
+++ b/types/types.ts
@@ -90,9 +90,7 @@ export type Option = {
 };
 
 export type CoinState = {
-  currency: CurrencyValue;
   currencyKey: CurrencyKey;
-  ticker: TickerValue;
   tickerKey: TickerKey;
 };
 

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -1,5 +1,5 @@
 import { SPECS_CURRENCIES, SPECS_TICKERS } from '@/constants/Api';
-import { TickerKey, CurrencyKey } from '@/types/types';
+import { TickerKey, CurrencyKey, CurrencyValue, TickerValue } from '@/types/types';
 
 export const debounce = (func: Function, delay: number) => {
   let timer: NodeJS.Timeout;
@@ -16,3 +16,7 @@ export const isCurrencyKey = (key: TickerKey | CurrencyKey): key is CurrencyKey 
 export const isTickerKey = (key: TickerKey | CurrencyKey): key is TickerKey => {
   return key in SPECS_TICKERS;
 };
+
+export const getTicker = (tickerKey: TickerKey): TickerValue => SPECS_TICKERS[tickerKey];
+
+export const getCurrency = (currencyKey: CurrencyKey): CurrencyValue => SPECS_CURRENCIES[currencyKey];


### PR DESCRIPTION
modified:   constants/Api.ts
  removed bhd, BHD

modified:   contexts/coinsContext.tsx
  removed currency and ticker from coinState - they can be derived

modified:   hooks/useTickerData.ts
  uses new getTicker & getCurrency utils functions instead of coinState.currency coinState.ticker
  guards added

modified:   types/types.ts
  see epic

modified:   utils/utils.ts
  2 helper functions added
  getTicker
  getCurrency